### PR TITLE
Se solucionó el error que provocaba peticiones infinitas en los filtros

### DIFF
--- a/src/components/filters/index.tsx
+++ b/src/components/filters/index.tsx
@@ -37,7 +37,7 @@ const Filters = () => {
       .then((data) => {
         setBrands(data);
       });
-  });
+  },[]);
 
   const toggleDisplay = (name: string) => {
     setState((prevState) => {


### PR DESCRIPTION
En la ruta de /products ya no hace peticiones infinitas al backend para obtener las marcas y categorías.