### PR TITLE
Fix width in viewProducts container

### DIFF
--- a/src/components/viewProducts/index.tsx
+++ b/src/components/viewProducts/index.tsx
@@ -6,7 +6,7 @@ import Filters from '../filters';
 const ViewProducts: FC = () => {
   return (
     <section className="w-full flex flex-col items-start justify-between md:gap-x-5 gap-y-6 md:gap-y-0 mt-20 md:mt-0 max-w-[1920px] mx-auto">
-      <div className='flex-col md:flex-row flex min-h-max'>
+      <div className='w-full flex-col md:flex-row flex min-h-max'>
         <div className='flex flex-col items-start w-full md:w-1/4 p-10 min-h-max md:bg-gray md:pt-10 pt-20 dark:bg-[#252525]'>
             <Filters />
         </div>


### PR DESCRIPTION
El contenedor de filtros y productos ahora tiene un ancho definido al 100% evitando cualquier visualización horrible para el usuario.