### PR TITLE
Se especifica el tipo de referencia

### DIFF
--- a/src/components/containerCards/containerCardsBrands.tsx
+++ b/src/components/containerCards/containerCardsBrands.tsx
@@ -129,14 +129,15 @@ const ContainerCardsBrands: React.FC = () => {
   };
 
   const [activeIndex, setActiveIndex] = useState(0);
-  const tickerRef = useRef(null);
-
+  const tickerRef = useRef<HTMLDivElement>(null);
+  
   const value: AnimatedValue = {
     animate() {
-      // Implement the animate method
+      // Implement the actual animation logic here
+      // You can use `tickerRef.current` to access the ticker element
+      // and animate its properties
     },
   };
-  value.animate(); // This will work because value is an AnimatedValue
 
   const prevSlide = () => {
     const isFirstSlide = activeIndex === 0;


### PR DESCRIPTION
Me acabo de fijar que esa línea de código no se subió a la rama, ahora si; era especificar el tipo de la referencia utilizando React.RefObject y HTMLDivElement, para corregir ese error. 